### PR TITLE
Add IP-based identity hash to messages

### DIFF
--- a/server/src/db/migrations/002_add_ip_salt.sql
+++ b/server/src/db/migrations/002_add_ip_salt.sql
@@ -1,0 +1,3 @@
+ALTER TABLE security_codes ADD COLUMN IF NOT EXISTS ip_salt VARCHAR(64);
+
+UPDATE security_codes SET ip_salt = gen_random_uuid()::VARCHAR WHERE ip_salt IS NULL;

--- a/server/src/public/index.html
+++ b/server/src/public/index.html
@@ -145,6 +145,12 @@ body {
   color: #e94560;
   font-size: 0.9rem;
 }
+.message .meta .name .hash {
+  font-weight: 400;
+  color: #888;
+  font-size: 0.8rem;
+  font-family: monospace;
+}
 .message .meta .time {
   font-size: 0.75rem;
   color: #666;
@@ -339,8 +345,9 @@ body {
     div.className = 'message';
     div.dataset.id = msg.id;
     const time = new Date(msg.created_at).toLocaleString();
+    var displayName = msg.hash ? escapeHtml(msg.name) + '<span class="hash">[' + escapeHtml(msg.hash) + ']</span>' : escapeHtml(msg.name);
     div.innerHTML =
-      '<div class="meta"><span class="name">' + escapeHtml(msg.name) + '</span><span class="time">' + escapeHtml(time) + '</span></div>' +
+      '<div class="meta"><span class="name">' + displayName + '</span><span class="time">' + escapeHtml(time) + '</span></div>' +
       '<div class="body">' + escapeHtml(msg.text) + '</div>';
     return div;
   }

--- a/server/src/routes/messages.ts
+++ b/server/src/routes/messages.ts
@@ -1,17 +1,38 @@
 import { Router, Request, Response } from "express";
+import crypto from "crypto";
 import pool from "../db/pool";
 import { broadcast } from "../websocket";
 
 const router = Router();
 
+let cachedSalt: string | null = null;
+
+async function getSalt(): Promise<string> {
+  if (cachedSalt) return cachedSalt;
+  const { rows } = await pool.query("SELECT ip_salt FROM security_codes LIMIT 1");
+  cachedSalt = rows[0].ip_salt;
+  return cachedSalt!;
+}
+
+function hashIp(ip: string, salt: string): string {
+  return crypto.createHash("sha256").update(ip + salt).digest("hex").slice(0, 6);
+}
+
+function addHash(row: any, salt: string) {
+  const { client_ip, ...rest } = row;
+  return { ...rest, hash: hashIp(client_ip, salt) };
+}
+
 router.get("/", async (req: Request, res: Response): Promise<void> => {
   const afterId = req.query.after_id ? parseInt(req.query.after_id as string, 10) : null;
   const page = req.query.page ? parseInt(req.query.page as string, 10) : null;
 
+  const salt = await getSalt();
+
   if (afterId !== null) {
     // Cursor-based: chronological order, 100 after given ID
     const { rows } = await pool.query(
-      `SELECT id, name, text, created_at FROM messages
+      `SELECT id, name, text, client_ip, created_at FROM messages
        WHERE id > $1 ORDER BY id ASC LIMIT 100`,
       [afterId]
     );
@@ -22,7 +43,7 @@ router.get("/", async (req: Request, res: Response): Promise<void> => {
     );
 
     res.json({
-      messages: rows,
+      messages: rows.map(r => addHash(r, salt)),
       pagination: {
         after_id: afterId,
         has_more: countResult.rows[0].cnt > 100,
@@ -38,7 +59,7 @@ router.get("/", async (req: Request, res: Response): Promise<void> => {
   const offset = (currentPage - 1) * limit;
 
   const { rows } = await pool.query(
-    `SELECT id, name, text, created_at FROM messages
+    `SELECT id, name, text, client_ip, created_at FROM messages
      ORDER BY id DESC LIMIT $1 OFFSET $2`,
     [limit, offset]
   );
@@ -47,7 +68,7 @@ router.get("/", async (req: Request, res: Response): Promise<void> => {
   const total = totalResult.rows[0].cnt;
 
   res.json({
-    messages: rows,
+    messages: rows.map(r => addHash(r, salt)),
     pagination: {
       page: currentPage,
       has_more: offset + rows.length < total,
@@ -70,6 +91,7 @@ router.post("/", async (req: Request, res: Response): Promise<void> => {
   }
 
   const clientIp = req.ip || "unknown";
+  const salt = await getSalt();
 
   const { rows } = await pool.query(
     `INSERT INTO messages (name, text, client_ip)
@@ -78,7 +100,7 @@ router.post("/", async (req: Request, res: Response): Promise<void> => {
     [name, text, clientIp]
   );
 
-  const message = rows[0];
+  const message = { ...rows[0], hash: hashIp(clientIp, salt) };
 
   // Broadcast to WebSocket clients
   broadcast({


### PR DESCRIPTION
## Summary
- Messages now include a `hash` field: 6-char hex from `sha256(client_ip + salt)`
- Same IP always produces the same hash, so users can identify repeat senders
- WebUI displays messages as `Name[hash]` with the hash in muted monospace
- Salt is generated once per server instance (migration `002_add_ip_salt.sql`)
- Client IPs remain hidden — only the hash is exposed

## Test plan
- [x] `hash` field present on POST response (6 hex chars)
- [x] `hash` field present on GET responses (page + cursor)
- [x] `hash` field present on WebSocket broadcast
- [x] Same client IP produces consistent hash across messages
- [x] `client_ip` still never exposed in API responses
- [x] All 19 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)