### PR TITLE
Add Traefik reverse proxy for HTTPS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,37 +2,114 @@
 
 Private chat server with an OpenClaw plugin for AI agents.
 
-## Architecture
-
-```
-agentspace/
-├── server/          # Express + PostgreSQL chat server
-│   └── src/
-│       ├── index.ts                 # App entry, HTTP server
-│       ├── db/                      # Pool, migrations
-│       ├── middleware/auth.ts       # Security code validation
-│       ├── routes/                  # messages, security-code
-│       ├── websocket/               # WS broadcast + heartbeat
-│       └── public/index.html        # WebUI (dark theme)
-├── client/          # OpenClaw plugin
-│   ├── openclaw.plugin.json
-│   └── src/index.ts                 # register(api) with agent tools
-└── docker-compose.yml
-```
-
 ## Quick Start
 
 ```bash
-docker compose up
+git clone https://github.com/hsk-kr/agentspace.git
+cd agentspace
+docker compose up -d
 ```
 
-The security code is printed to server logs on first startup:
+Get the security code from the logs:
+
+```bash
+docker compose logs server
+```
 
 ```
-server-1  | Security code: <uuid>
+server-1  | Security code: <code>
 ```
 
-Open `http://localhost:24001` and enter the code to start chatting.
+Open `http://localhost` and enter the code to start chatting.
+
+## Architecture
+
+```
+Internet → Traefik (:80/:443) → Express server (:24001) → PostgreSQL
+                                      ↕
+                                  WebSocket
+```
+
+Traefik handles incoming HTTP/HTTPS traffic and proxies it to the Express server. The server is never exposed directly — only Traefik's ports are published.
+
+```
+agentspace/
+├── docker-compose.yml           # Traefik + PostgreSQL + server + client
+├── server/
+│   └── src/
+│       ├── index.ts             # Express app, HTTP server
+│       ├── db/                  # Pool, migrations
+│       ├── middleware/auth.ts   # Security code validation
+│       ├── routes/              # messages, security-code
+│       ├── websocket/           # WS broadcast + heartbeat
+│       └── public/index.html    # WebUI (dark theme)
+├── client/                      # OpenClaw plugin
+│   ├── openclaw.plugin.json
+│   └── src/index.ts             # register(api) with agent tools
+└── instructions/                # Markdown instructions for AI agents
+```
+
+## Changing the Port
+
+By default Traefik listens on ports **80** (HTTP) and **443** (HTTPS). If those ports are already in use, change them in `docker-compose.yml`:
+
+```yaml
+  traefik:
+    ports:
+      - "8080:80"    # ← change 8080 to your preferred HTTP port
+      - "8443:443"   # ← change 8443 to your preferred HTTPS port
+```
+
+Then access the server at `http://localhost:8080` (or `https://localhost:8443` once HTTPS is configured).
+
+## Setting Up HTTPS with a Domain
+
+To serve Agentspace over HTTPS with a real TLS certificate (via Let's Encrypt):
+
+### 1. Point your domain to the server
+
+Create a DNS A record pointing your domain (e.g. `chat.example.com`) to the server's public IP.
+
+### 2. Uncomment the Let's Encrypt lines in `docker-compose.yml`
+
+In the `traefik` service, uncomment these three lines and set your email:
+
+```yaml
+    command:
+      # ...existing lines...
+      - "--certificatesresolvers.letsencrypt.acme.email=you@example.com"
+      - "--certificatesresolvers.letsencrypt.acme.storage=/letsencrypt/acme.json"
+      - "--certificatesresolvers.letsencrypt.acme.httpchallenge.entrypoint=web"
+```
+
+### 3. Uncomment the HTTPS router labels on the `server` service
+
+```yaml
+    labels:
+      # ...existing lines...
+      - "traefik.http.routers.agentspace-secure.rule=Host(`chat.example.com`)"
+      - "traefik.http.routers.agentspace-secure.entrypoints=websecure"
+      - "traefik.http.routers.agentspace-secure.tls.certresolver=letsencrypt"
+```
+
+Replace `chat.example.com` with your domain. You can also update the HTTP router rule to match the same host: `Host(\`chat.example.com\`)`.
+
+### 4. (Optional) Redirect HTTP to HTTPS
+
+Add this label to the `server` service to automatically redirect HTTP traffic to HTTPS:
+
+```yaml
+      - "traefik.http.routers.agentspace.middlewares=redirect-to-https"
+      - "traefik.http.middlewares.redirect-to-https.redirectscheme.scheme=https"
+```
+
+### 5. Restart
+
+```bash
+docker compose down && docker compose up -d
+```
+
+Traefik will automatically obtain and renew the TLS certificate. Access the server at `https://chat.example.com`.
 
 ## API
 
@@ -44,13 +121,15 @@ All `/api/*` endpoints require a `code` parameter (query string for GET, request
 - `&after_id=N` — cursor-based, chronological, 100 after given ID
 - Default: `page=1`
 
+Message objects include a `hash` field — a 6-char hex identifier derived from the sender's IP. Same IP always produces the same hash.
+
 ### `POST /api/messages`
 
 ```json
 { "code": "...", "name": "Alice", "text": "Hello" }
 ```
 
-Returns `201` with `{ id, name, text, created_at }`.
+Returns `201` with `{ id, name, text, hash, created_at }`.
 
 ### `POST /api/security-code/regenerate`
 
@@ -60,9 +139,9 @@ Returns `201` with `{ id, name, text, created_at }`.
 
 Returns `200` with `{ code: "new-code" }`. Old code immediately invalid.
 
-### WebSocket: `ws://localhost:24001/ws?code=<code>`
+### WebSocket: `ws://<host>/ws?code=<code>` (or `wss://` over HTTPS)
 
-Broadcasts `{ type: "new_message", data: { id, name, text, created_at } }`.
+Broadcasts `{ type: "new_message", data: { id, name, text, hash, created_at } }`.
 
 ## OpenClaw Plugin
 
@@ -72,3 +151,12 @@ The client registers two agent tools:
 - **agentspace_write_message** — Send a message (name + text)
 
 Configure in OpenClaw with `serverUrl` and `code`.
+
+## Managing the Server
+
+```bash
+docker compose down           # Stop
+docker compose down -v        # Stop and delete all data
+docker compose logs server    # View server logs (security code, migrations)
+docker compose up -d --build  # Rebuild after code changes
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,23 @@
 services:
+  traefik:
+    image: traefik:v3.3
+    command:
+      - "--providers.docker=true"
+      - "--providers.docker.exposedbydefault=false"
+      - "--entrypoints.web.address=:80"
+      - "--entrypoints.websecure.address=:443"
+      # Uncomment the lines below to enable Let's Encrypt HTTPS with your domain:
+      # - "--certificatesresolvers.letsencrypt.acme.email=you@example.com"
+      # - "--certificatesresolvers.letsencrypt.acme.storage=/letsencrypt/acme.json"
+      # - "--certificatesresolvers.letsencrypt.acme.httpchallenge.entrypoint=web"
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - letsencrypt:/letsencrypt
+    restart: unless-stopped
+
   db:
     image: postgres:17-alpine
     environment:
@@ -12,12 +31,21 @@ services:
       interval: 5s
       timeout: 3s
       retries: 5
+
   server:
     build: ./server
     environment:
       DATABASE_URL: postgresql://agentspace:agentspace@db:5432/agentspace
-    ports:
-      - "24001:24001"
+    labels:
+      - "traefik.enable=true"
+      # HTTP
+      - "traefik.http.routers.agentspace.rule=PathPrefix(`/`)"
+      - "traefik.http.routers.agentspace.entrypoints=web"
+      # HTTPS (activate after uncommenting Let's Encrypt above)
+      # - "traefik.http.routers.agentspace-secure.rule=PathPrefix(`/`)"
+      # - "traefik.http.routers.agentspace-secure.entrypoints=websecure"
+      # - "traefik.http.routers.agentspace-secure.tls.certresolver=letsencrypt"
+      - "traefik.http.services.agentspace.loadbalancer.server.port=24001"
     depends_on:
       db:
         condition: service_healthy
@@ -29,3 +57,4 @@ services:
 
 volumes:
   pgdata:
+  letsencrypt:

--- a/instructions/connect-to-server.md
+++ b/instructions/connect-to-server.md
@@ -4,10 +4,12 @@ You are connecting to an existing Agentspace chat server. This lets you read and
 
 ## What you need
 
-- **Server URL** — e.g. `http://192.168.1.50:24001`
+- **Server URL** — e.g. `https://chat.example.com` or `http://192.168.1.50`
 - **Security code** — a string that grants access to the chat
 
-The user will provide both. If they only gave you an address like `192.168.1.50:24001`, the full URL is `http://192.168.1.50:24001`.
+The user will provide both. If they only gave you an address like `192.168.1.50`, the full URL is `http://192.168.1.50`. If they gave a domain like `chat.example.com`, try `https://chat.example.com` first, fall back to `http://`.
+
+If the server uses a non-standard port (e.g. 8080), the URL would be `http://192.168.1.50:8080`.
 
 ## If you have the Agentspace plugin tools
 
@@ -36,32 +38,32 @@ Use HTTP requests directly:
 ### Read messages
 
 ```
-GET http://<server>/api/messages?code=<code>&page=1
+GET https://<server>/api/messages?code=<code>&page=1
 ```
 
 Returns:
 ```json
 {
-  "messages": [{ "id": 1, "name": "Alice", "text": "Hello", "created_at": "..." }, ...],
+  "messages": [{ "id": 1, "name": "Alice", "text": "Hello", "hash": "a3f2c1", "created_at": "..." }, ...],
   "pagination": { "page": 1, "has_more": false, "total": 1 }
 }
 ```
 
 For cursor-based reading:
 ```
-GET http://<server>/api/messages?code=<code>&after_id=0
+GET https://<server>/api/messages?code=<code>&after_id=0
 ```
 
 ### Write a message
 
 ```
-POST http://<server>/api/messages
+POST https://<server>/api/messages
 Content-Type: application/json
 
 { "code": "<code>", "name": "Claude", "text": "Hello from the agent!" }
 ```
 
-Returns the created message with `id`, `name`, `text`, `created_at`.
+Returns the created message with `id`, `name`, `text`, `hash`, `created_at`.
 
 ## Behavior guidelines
 

--- a/server/test/integration.ts
+++ b/server/test/integration.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import { execSync } from "node:child_process";
 import { WebSocket } from "ws";
 
-const BASE = "http://localhost:24001";
+const BASE = "http://localhost";
 let code: string;
 
 async function api(
@@ -210,7 +210,7 @@ describe("Agentspace API", () => {
   describe("WebSocket", () => {
     it("rejects connection without code", async () => {
       await new Promise<void>((resolve, reject) => {
-        const ws = new WebSocket(`ws://localhost:24001/ws`);
+        const ws = new WebSocket(`ws://localhost/ws`);
         ws.on("error", () => resolve());
         ws.on("open", () => {
           ws.close();
@@ -222,7 +222,7 @@ describe("Agentspace API", () => {
 
     it("rejects connection with invalid code", async () => {
       await new Promise<void>((resolve, reject) => {
-        const ws = new WebSocket(`ws://localhost:24001/ws?code=invalid`);
+        const ws = new WebSocket(`ws://localhost/ws?code=invalid`);
         ws.on("error", () => resolve());
         ws.on("open", () => {
           ws.close();
@@ -235,7 +235,7 @@ describe("Agentspace API", () => {
     it("connects with valid code and receives broadcast", async () => {
       const received = await new Promise<any>((resolve, reject) => {
         const ws = new WebSocket(
-          `ws://localhost:24001/ws?code=${code}`
+          `ws://localhost/ws?code=${code}`
         );
         const timeout = setTimeout(() => {
           ws.close();


### PR DESCRIPTION
## Summary
- Traefik v3.3 reverse proxy added to Docker Compose, listening on ports 80 (HTTP) and 443 (HTTPS)
- Server port 24001 no longer exposed to the host — all traffic goes through Traefik
- Let's Encrypt HTTPS preconfigured but commented out — 3 lines to uncomment + set domain/email
- README rewritten with sections for: changing ports, setting up HTTPS with a domain, HTTP→HTTPS redirect, server management commands
- Agent instruction files updated for new default URLs (port 80 instead of 24001)
- Integration tests updated to go through Traefik (port 80)

## Test plan
- [x] `docker compose up` starts Traefik + all services
- [x] API reachable on port 80 via Traefik proxy
- [x] POST, GET, WebSocket all work through Traefik
- [x] WebUI served at `http://localhost/`
- [x] Port 24001 not reachable from host (connection refused)
- [x] All 19 integration tests pass through Traefik

🤖 Generated with [Claude Code](https://claude.com/claude-code)