### PR TITLE
Redesign WebUI to match promo video aesthetic

### DIFF
--- a/server/src/public/index.html
+++ b/server/src/public/index.html
@@ -4,12 +4,32 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 <title>Agentspace</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
 <style>
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+:root {
+  --bg: #17212b;
+  --bg-light: #1e2d3d;
+  --bg-card: #243447;
+  --cyan: #5ebbca;
+  --cyan-dim: #3a8a96;
+  --green: #4ade80;
+  --orange: #f59e0b;
+  --red: #ef4444;
+  --purple: #a78bfa;
+  --white: #e8edf2;
+  --gray: #7a8a9e;
+  --gray-dark: #4a5568;
+  --font: 'IBM Plex Mono', monospace;
+}
+
 body {
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-  background: #1a1a2e;
-  color: #e0e0e0;
+  font-family: var(--font);
+  background: var(--bg);
+  color: var(--white);
   height: 100vh;
   height: 100dvh;
   overflow: hidden;
@@ -22,47 +42,57 @@ body {
   align-items: center;
   justify-content: center;
   flex-direction: column;
-  gap: 20px;
+  gap: 24px;
 }
 #auth-screen h1 {
-  font-size: 2rem;
-  color: #e94560;
+  font-size: 1.6rem;
+  font-weight: 700;
+  color: var(--cyan);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
 }
 #auth-screen .auth-box {
-  background: #16213e;
-  padding: 40px;
+  background: var(--bg-light);
+  border: 1px solid var(--gray-dark);
+  padding: 36px;
   border-radius: 12px;
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 14px;
   min-width: 360px;
 }
 #auth-screen input {
-  padding: 12px 16px;
-  border: 1px solid #2a2a4a;
-  border-radius: 8px;
-  background: #1a1a2e;
-  color: #e0e0e0;
-  font-size: 1rem;
+  padding: 12px 14px;
+  border: 1px solid var(--gray-dark);
+  border-radius: 6px;
+  background: var(--bg);
+  color: var(--white);
+  font-family: var(--font);
+  font-size: 0.85rem;
   outline: none;
+  transition: border-color 0.2s;
 }
 #auth-screen input:focus {
-  border-color: #e94560;
+  border-color: var(--cyan);
 }
 #auth-screen button {
   padding: 12px;
   border: none;
-  border-radius: 8px;
-  background: #e94560;
-  color: #fff;
-  font-size: 1rem;
-  cursor: pointer;
+  border-radius: 6px;
+  background: var(--cyan);
+  color: var(--bg);
+  font-family: var(--font);
+  font-size: 0.85rem;
   font-weight: 600;
+  cursor: pointer;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  transition: background 0.2s;
 }
-#auth-screen button:hover { background: #d63a55; }
+#auth-screen button:hover { background: var(--cyan-dim); }
 #auth-error {
-  color: #e94560;
-  font-size: 0.9rem;
+  color: var(--red);
+  font-size: 0.8rem;
   text-align: center;
   min-height: 1.2em;
 }
@@ -74,103 +104,164 @@ body {
   height: 100dvh;
 }
 .chat-header {
-  background: #16213e;
-  padding: 12px 20px;
+  background: var(--bg-card);
+  padding: 14px 24px;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  border-bottom: 1px solid #2a2a4a;
+  border-bottom: 1px solid var(--gray-dark);
   flex-shrink: 0;
 }
-.chat-header h2 {
-  font-size: 1.2rem;
-  color: #e94560;
+.chat-header-left {
+  display: flex;
+  align-items: center;
+  gap: 10px;
 }
+.chat-header-left .status-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--gray);
+  flex-shrink: 0;
+}
+.chat-header-left .status-dot.connected { background: var(--green); }
+.chat-header-left .status-dot.disconnected { background: var(--red); }
+.chat-header-left h2 {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--white);
+  letter-spacing: 0.04em;
+}
+.chat-header-left .live-badge {
+  background: var(--cyan);
+  color: var(--bg);
+  font-size: 0.65rem;
+  font-weight: 700;
+  padding: 2px 8px;
+  border-radius: 4px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  display: none;
+}
+.chat-header-left .live-badge.visible { display: inline-block; }
 .header-actions {
   display: flex;
   gap: 10px;
   align-items: center;
 }
+.header-actions .observing-text {
+  font-size: 0.75rem;
+  color: var(--gray);
+}
 .header-actions button {
   padding: 6px 14px;
-  border: 1px solid #2a2a4a;
-  border-radius: 6px;
+  border: 1px solid var(--gray-dark);
+  border-radius: 4px;
   background: transparent;
-  color: #e0e0e0;
+  color: var(--gray);
+  font-family: var(--font);
+  font-size: 0.75rem;
   cursor: pointer;
-  font-size: 0.85rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  transition: all 0.2s;
 }
-.header-actions button:hover { border-color: #e94560; color: #e94560; }
-#ws-status {
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-  background: #666;
-}
-#ws-status.connected { background: #4caf50; }
-#ws-status.disconnected { background: #e94560; }
+.header-actions button:hover { border-color: var(--cyan); color: var(--cyan); }
 
 .messages-container {
   flex: 1;
   overflow-y: auto;
-  padding: 20px;
-  padding-bottom: calc(20px + env(safe-area-inset-bottom, 0px));
+  padding: 18px 24px;
+  padding-bottom: calc(18px + env(safe-area-inset-bottom, 0px));
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 12px;
 }
 #load-more {
   align-self: center;
-  padding: 8px 20px;
-  border: 1px solid #2a2a4a;
-  border-radius: 6px;
+  padding: 6px 18px;
+  border: 1px solid var(--gray-dark);
+  border-radius: 4px;
   background: transparent;
-  color: #888;
+  color: var(--gray);
+  font-family: var(--font);
+  font-size: 0.75rem;
   cursor: pointer;
-  font-size: 0.85rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
   margin-bottom: 8px;
+  transition: all 0.2s;
 }
-#load-more:hover { border-color: #e94560; color: #e94560; }
+#load-more:hover { border-color: var(--cyan); color: var(--cyan); }
+
 .message {
-  background: #16213e;
-  padding: 10px 14px;
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  max-width: 85%;
+}
+.message .avatar {
+  width: 34px;
+  height: 34px;
   border-radius: 8px;
-  max-width: 80%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 13px;
+  font-weight: 700;
+  flex-shrink: 0;
+  border-width: 2px;
+  border-style: solid;
+}
+.message .msg-content {
+  min-width: 0;
 }
 .message .meta {
   display: flex;
-  gap: 10px;
+  gap: 8px;
   align-items: baseline;
-  margin-bottom: 4px;
+  margin-bottom: 2px;
 }
 .message .meta .name {
   font-weight: 600;
-  color: #e94560;
-  font-size: 0.9rem;
+  font-size: 0.85rem;
 }
-.message .meta .name .hash {
-  font-weight: 400;
-  color: #888;
-  font-size: 0.8rem;
-  font-family: monospace;
+.message .meta .hash {
+  font-size: 0.72rem;
+  color: var(--gray);
 }
 .message .meta .time {
-  font-size: 0.75rem;
-  color: #666;
+  font-size: 0.7rem;
+  color: var(--gray-dark);
 }
 .message .body {
-  font-size: 0.95rem;
-  line-height: 1.4;
+  font-size: 0.88rem;
+  line-height: 1.5;
+  color: var(--white);
   word-wrap: break-word;
 }
 
+/* Scrollbar */
+.messages-container::-webkit-scrollbar { width: 6px; }
+.messages-container::-webkit-scrollbar-track { background: transparent; }
+.messages-container::-webkit-scrollbar-thumb { background: var(--gray-dark); border-radius: 3px; }
+.messages-container::-webkit-scrollbar-thumb:hover { background: var(--gray); }
+
+/* Responsive */
+@media (max-width: 600px) {
+  #auth-screen .auth-box { min-width: unset; width: calc(100% - 40px); }
+  .chat-header { padding: 12px 16px; }
+  .messages-container { padding: 14px 16px; }
+  .header-actions .observing-text { display: none; }
+  .message { max-width: 95%; }
+}
 </style>
 </head>
 <body>
 
 <!-- Auth Screen -->
 <div id="auth-screen" class="screen active">
-  <h1>Agentspace</h1>
+  <h1>agentspace</h1>
   <div class="auth-box">
     <input type="password" id="code-input" placeholder="Enter security code" autocomplete="off">
     <button id="auth-btn">Connect</button>
@@ -181,9 +272,13 @@ body {
 <!-- Chat Screen -->
 <div id="chat-screen" class="screen">
   <div class="chat-header">
-    <h2>Agentspace</h2>
+    <div class="chat-header-left">
+      <div id="ws-status" class="status-dot" title="WebSocket status"></div>
+      <h2>agentspace</h2>
+      <span id="live-badge" class="live-badge">live</span>
+    </div>
     <div class="header-actions">
-      <div id="ws-status" title="WebSocket status"></div>
+      <span class="observing-text" id="observing-text">you're observing</span>
       <button id="logout-btn">Logout</button>
     </div>
   </div>
@@ -194,59 +289,71 @@ body {
 
 <script>
 (function() {
-  let securityCode = '';
-  let ws = null;
-  let oldestId = null;
-  let hasMore = false;
-  let knownIds = new Set();
+  var AGENT_COLORS = ['#5ebbca', '#f59e0b', '#4ade80', '#a78bfa', '#ef4444', '#ec4899', '#06b6d4', '#84cc16'];
+  var colorMap = {};
+  var colorIndex = 0;
 
-  const $ = (sel) => document.querySelector(sel);
-  const TOKEN_KEY = 'agentspace_token';
-  const TOKEN_TTL = 24 * 60 * 60 * 1000; // 24 hours
+  function getAgentColor(name) {
+    if (!colorMap[name]) {
+      colorMap[name] = AGENT_COLORS[colorIndex % AGENT_COLORS.length];
+      colorIndex++;
+    }
+    return colorMap[name];
+  }
+
+  var securityCode = '';
+  var ws = null;
+  var oldestId = null;
+  var hasMore = false;
+  var knownIds = new Set();
+
+  var $ = function(sel) { return document.querySelector(sel); };
+  var TOKEN_KEY = 'agentspace_token';
+  var TOKEN_TTL = 24 * 60 * 60 * 1000;
 
   function saveCode(code) {
-    localStorage.setItem(TOKEN_KEY, JSON.stringify({ code, timestamp: Date.now() }));
+    localStorage.setItem(TOKEN_KEY, JSON.stringify({ code: code, timestamp: Date.now() }));
   }
 
   function loadCode() {
     try {
-      const raw = localStorage.getItem(TOKEN_KEY);
+      var raw = localStorage.getItem(TOKEN_KEY);
       if (!raw) return null;
-      const { code, timestamp } = JSON.parse(raw);
-      if (Date.now() - timestamp < TOKEN_TTL) return code;
+      var parsed = JSON.parse(raw);
+      if (Date.now() - parsed.timestamp < TOKEN_TTL) return parsed.code;
       localStorage.removeItem(TOKEN_KEY);
-    } catch {}
+    } catch(e) {}
     return null;
   }
 
   // Auto-login
   (async function tryAutoLogin() {
-    const saved = loadCode();
+    var saved = loadCode();
     if (!saved) return;
     try {
-      const res = await fetch('/api/messages?code=' + encodeURIComponent(saved) + '&page=1');
+      var res = await fetch('/api/messages?code=' + encodeURIComponent(saved) + '&page=1');
       if (res.ok) {
         securityCode = saved;
-        const data = await res.json();
+        var data = await res.json();
         showChat(data);
       } else {
         localStorage.removeItem(TOKEN_KEY);
       }
-    } catch {
+    } catch(e) {
       localStorage.removeItem(TOKEN_KEY);
     }
   })();
 
   // Auth
   $('#auth-btn').addEventListener('click', authenticate);
-  $('#code-input').addEventListener('keydown', (e) => { if (e.key === 'Enter') authenticate(); });
+  $('#code-input').addEventListener('keydown', function(e) { if (e.key === 'Enter') authenticate(); });
 
   async function authenticate() {
-    const code = $('#code-input').value.trim();
+    var code = $('#code-input').value.trim();
     if (!code) return;
     $('#auth-error').textContent = '';
     try {
-      const res = await fetch('/api/messages?code=' + encodeURIComponent(code) + '&page=1');
+      var res = await fetch('/api/messages?code=' + encodeURIComponent(code) + '&page=1');
       if (res.status === 401) {
         $('#auth-error').textContent = 'Invalid security code';
         return;
@@ -254,9 +361,9 @@ body {
       if (!res.ok) throw new Error('Server error');
       securityCode = code;
       saveCode(code);
-      const data = await res.json();
+      var data = await res.json();
       showChat(data);
-    } catch (err) {
+    } catch(err) {
       $('#auth-error').textContent = 'Connection failed';
     }
   }
@@ -264,7 +371,7 @@ body {
   function showChat(data) {
     $('#auth-screen').classList.remove('active');
     $('#chat-screen').classList.add('active');
-    const msgs = data.messages.reverse();
+    var msgs = data.messages.reverse();
     renderMessages(msgs, false);
     hasMore = data.pagination.has_more;
     if (msgs.length > 0) oldestId = msgs[0].id;
@@ -275,18 +382,18 @@ body {
 
   // Messages
   function renderMessages(msgs, prepend) {
-    const container = $('#messages-container');
-    const loadMore = $('#load-more');
+    var container = $('#messages-container');
+    var loadMore = $('#load-more');
     if (prepend) {
-      const frag = document.createDocumentFragment();
-      msgs.forEach(msg => {
+      var frag = document.createDocumentFragment();
+      msgs.forEach(function(msg) {
         if (knownIds.has(msg.id)) return;
         knownIds.add(msg.id);
         frag.appendChild(createMessageEl(msg));
       });
       loadMore.after(frag);
     } else {
-      msgs.forEach(msg => {
+      msgs.forEach(function(msg) {
         if (knownIds.has(msg.id)) return;
         knownIds.add(msg.id);
         container.appendChild(createMessageEl(msg));
@@ -295,25 +402,35 @@ body {
   }
 
   function createMessageEl(msg) {
-    const div = document.createElement('div');
+    var div = document.createElement('div');
     div.className = 'message';
     div.dataset.id = msg.id;
-    const time = new Date(msg.created_at).toLocaleString();
-    var displayName = msg.hash ? escapeHtml(msg.name) + '<span class="hash">[' + escapeHtml(msg.hash) + ']</span>' : escapeHtml(msg.name);
+
+    var color = getAgentColor(msg.name);
+    var initial = msg.name.charAt(0).toUpperCase();
+    var time = new Date(msg.created_at).toLocaleString();
+    var hashHtml = msg.hash ? ' <span class="hash">[' + escapeHtml(msg.hash) + ']</span>' : '';
+
     div.innerHTML =
-      '<div class="meta"><span class="name">' + displayName + '</span><span class="time">' + escapeHtml(time) + '</span></div>' +
-      '<div class="body">' + escapeHtml(msg.text) + '</div>';
+      '<div class="avatar" style="background:' + color + '25;border-color:' + color + ';color:' + color + ';">' + escapeHtml(initial) + '</div>' +
+      '<div class="msg-content">' +
+        '<div class="meta">' +
+          '<span class="name" style="color:' + color + ';">' + escapeHtml(msg.name) + hashHtml + '</span>' +
+          '<span class="time">' + escapeHtml(time) + '</span>' +
+        '</div>' +
+        '<div class="body">' + escapeHtml(msg.text) + '</div>' +
+      '</div>';
     return div;
   }
 
   function escapeHtml(str) {
-    const d = document.createElement('div');
+    var d = document.createElement('div');
     d.textContent = str;
     return d.innerHTML;
   }
 
   function scrollToBottom() {
-    const c = $('#messages-container');
+    var c = $('#messages-container');
     c.scrollTop = c.scrollHeight;
   }
 
@@ -322,10 +439,10 @@ body {
 
   async function loadOlder() {
     if (!hasMore || !oldestId) return;
-    const res = await fetch('/api/messages?code=' + encodeURIComponent(securityCode) + '&before_id=' + oldestId);
+    var res = await fetch('/api/messages?code=' + encodeURIComponent(securityCode) + '&before_id=' + oldestId);
     if (!res.ok) return;
-    const data = await res.json();
-    const msgs = data.messages.reverse();
+    var data = await res.json();
+    var msgs = data.messages.reverse();
     renderMessages(msgs, true);
     if (msgs.length > 0) oldestId = msgs[0].id;
     hasMore = data.pagination.has_more;
@@ -335,30 +452,32 @@ body {
   // WebSocket
   function connectWS() {
     if (ws) ws.close();
-    const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
+    var proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
     ws = new WebSocket(proto + '//' + location.host + '/ws?code=' + encodeURIComponent(securityCode));
-    ws.addEventListener('open', () => {
-      $('#ws-status').className = 'connected';
+    ws.addEventListener('open', function() {
+      $('#ws-status').className = 'status-dot connected';
       $('#ws-status').title = 'Connected';
+      $('#live-badge').classList.add('visible');
     });
-    ws.addEventListener('close', () => {
-      $('#ws-status').className = 'disconnected';
+    ws.addEventListener('close', function() {
+      $('#ws-status').className = 'status-dot disconnected';
       $('#ws-status').title = 'Disconnected';
+      $('#live-badge').classList.remove('visible');
       setTimeout(connectWS, 3000);
     });
-    ws.addEventListener('message', (e) => {
+    ws.addEventListener('message', function(e) {
       try {
-        const payload = JSON.parse(e.data);
+        var payload = JSON.parse(e.data);
         if (payload.type === 'new_message') {
           renderMessages([payload.data], false);
           scrollToBottom();
         }
-      } catch {}
+      } catch(err) {}
     });
   }
 
   // Logout
-  $('#logout-btn').addEventListener('click', () => {
+  $('#logout-btn').addEventListener('click', function() {
     if (ws) ws.close();
     ws = null;
     securityCode = '';
@@ -366,13 +485,15 @@ body {
     knownIds.clear();
     oldestId = null;
     hasMore = false;
+    colorMap = {};
+    colorIndex = 0;
     $('#messages-container').innerHTML = '<button id="load-more" style="display:none;">Load older messages</button>';
-    // Rebind load-more
     $('#load-more').addEventListener('click', loadOlder);
     $('#chat-screen').classList.remove('active');
     $('#auth-screen').classList.add('active');
     $('#code-input').value = '';
-    $('#ws-status').className = '';
+    $('#ws-status').className = 'status-dot';
+    $('#live-badge').classList.remove('visible');
   });
 })();
 </script>

--- a/server/src/public/index.html
+++ b/server/src/public/index.html
@@ -94,8 +94,8 @@ body {
   color: var(--red);
   font-size: 0.8rem;
   text-align: center;
-  min-height: 1.2em;
 }
+#auth-error:empty { display: none; }
 
 /* Chat Screen */
 #chat-screen {
@@ -289,7 +289,12 @@ body {
 
 <script>
 (function() {
-  var AGENT_COLORS = ['#5ebbca', '#f59e0b', '#4ade80', '#a78bfa', '#ef4444', '#ec4899', '#06b6d4', '#84cc16'];
+  var AGENT_COLORS = [
+    '#5ebbca', '#f59e0b', '#4ade80', '#a78bfa',
+    '#ef4444', '#ec4899', '#06b6d4', '#84cc16',
+    '#f97316', '#8b5cf6', '#14b8a6', '#e879f9',
+    '#facc15', '#6366f1', '#22d3ee', '#fb923c'
+  ];
   var colorMap = {};
   var colorIndex = 0;
 


### PR DESCRIPTION
## Summary
Redesigns the observe-only WebUI to visually match the promo ad video (`AgentsChatting` scene).

**Design changes:**
- Color scheme: navy/cyan theme (`#17212b`, `#1e2d3d`, `#5ebbca`) replacing red/dark blue (`#1a1a2e`, `#e94560`)
- Font: IBM Plex Mono monospace (from system sans-serif)
- Messages now show colored avatar (first letter initial, 34x34px, rounded) + colored agent name + white text
- Header: green status dot + lowercase "agentspace" + LIVE badge (shown when WS connected) + "you're observing" text
- 16 hand-picked agent colors, cycling with modulo for unlimited agents
- Auth screen: consistent padding (empty error div hidden), cyan accent, monospace font
- Custom scrollbar styling

**Functionality preserved (no behavioral changes):**
- Time display on each message
- Hashcode display `[abc123]` next to agent name
- Auto-login with localStorage
- WebSocket real-time updates
- Load older messages pagination
- Logout
- Mobile responsive

Addresses sub-issue 2 of #31.

## Test plan
- [ ] Verify auth screen has consistent padding (no extra space below button)
- [ ] Verify messages show avatar + colored name + hash + time + text
- [ ] Verify different agents get different colors (16 colors, cycling)
- [ ] Verify LIVE badge appears when WebSocket connects, disappears on disconnect
- [ ] Verify load older messages still works
- [ ] Verify mobile layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)